### PR TITLE
Ignore CRD installer container name by VPA

### DIFF
--- a/helm/external-secrets/templates/crd-install/crd-job.yaml
+++ b/helm/external-secrets/templates/crd-install/crd-job.yaml
@@ -27,7 +27,7 @@ spec:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
       containers:
-      - name: kubectl
+      - name: {{ .Values.giantswarm.crds.podName }}
         image: "{{ .Values.giantswarm.images.registry }}/giantswarm/docker-kubectl:1.23.6"
         command:
         - sh

--- a/helm/external-secrets/templates/vpa.yaml
+++ b/helm/external-secrets/templates/vpa.yaml
@@ -21,6 +21,8 @@ spec:
           cpu: {{ .Values.giantswarm.resources.externalSecrets.requests.cpu }}
           memory: {{ .Values.giantswarm.resources.externalSecrets.requests.memory }}
         mode: Auto
+      - containerName: {{ .Values.giantswarm.crds.podName }}
+        mode: Off
   targetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/helm/external-secrets/values.schema.json
+++ b/helm/external-secrets/values.schema.json
@@ -202,6 +202,9 @@
                         "install": {
                             "type": "boolean"
                         },
+                        "podName": {
+                            "type": "string"
+                        },
                         "resources": {
                             "type": "object",
                             "properties": {

--- a/helm/external-secrets/values.yaml
+++ b/helm/external-secrets/values.yaml
@@ -57,6 +57,7 @@ giantswarm:
 
   crds:
     install: true
+    podName: kubectl
     resources:
       requests:
         memory: "256Mi"


### PR DESCRIPTION
There is possibly a bug in VPA selector and it targets the kubectl container in the CRD installer jobs pod.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
