### PR TITLE
Remove ingress from network policy

### DIFF
--- a/helm/external-secrets/templates/cilium-network-policy.yaml
+++ b/helm/external-secrets/templates/cilium-network-policy.yaml
@@ -37,9 +37,6 @@ spec:
         - ipBlock:
             cidr: {{ . }}
     {{- end }}
-  # deny ingress traffic
-  ingress: []
   policyTypes:
     - Egress
-    - Ingress
 {{- end }}


### PR DESCRIPTION
The network policy is currently configured to block ingress however this is required for the API server to talk to the webhook controller

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
