### PR TITLE
Cilium needs apiserver (and cluster) ingress

### DIFF
--- a/helm/external-secrets/templates/cilium-network-policy.yaml
+++ b/helm/external-secrets/templates/cilium-network-policy.yaml
@@ -11,6 +11,10 @@ spec:
     - kube-apiserver
     - cluster
     - world
+  ingress:
+  - fromEntities:
+    - kube-apiserver
+    - cluster
   endpointSelector: {}
 {{- else }}
 kind: NetworkPolicy


### PR DESCRIPTION
The cilium network policy is blocking access to the webhook validation. This commit allows cluster and apiserver access to the external-secrets pods.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
