### PR TITLE
Add ingress to netpol

### DIFF
--- a/helm/external-secrets/templates/network-policy.yaml
+++ b/helm/external-secrets/templates/network-policy.yaml
@@ -11,6 +11,8 @@ spec:
     matchLabels:
       {{- include "common.selectorLabels" . | nindent 6 }}
   # allow egress traffic to the Kubernetes API
+  ingress:
+  - {}
   egress:
     - ports:
         - port: 443
@@ -24,5 +26,6 @@ spec:
             cidr: {{ . }}
     {{- end }}
   policyTypes:
+    - Ingress
     - Egress
 {{ end }}


### PR DESCRIPTION
Network policy needs Ingress adding in. It blocks all without.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
