### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.8.0] - 2023-11-28
 
 ### Added
@@ -103,12 +107,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `external-secrets.name` instead of `external-secrets.fullname` for resource names prefix
 - Update ATS tests to use `v0.2.1` from `giantswarm-catalog`
 - Update `README.md`
-
-## [0.2.1] - 2023-01-16
-
-### Fixed
-
-- Fix more release issues
 
 ## [0.2.1] - 2023-01-16
 

--- a/helm/external-secrets/values.yaml
+++ b/helm/external-secrets/values.yaml
@@ -1,6 +1,6 @@
 giantswarm:
   images:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     externalSecrets:
       image: giantswarm/external-secrets
       tag: ""


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
