### PR TITLE
Fix broken policy exception for crd install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix policy exception
+
 ## [0.8.3] - 2024-02-20
 
 ### Fixed

--- a/helm/external-secrets/templates/crd-install/crd-kyverno-policy-exception.yaml
+++ b/helm/external-secrets/templates/crd-install/crd-kyverno-policy-exception.yaml
@@ -1,5 +1,5 @@
 {{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
   name: {{ include "external-secrets.name" . }}-crd


### PR DESCRIPTION
Policy exception for CRD install checks for PolicyException version v2alpha1 but applies v2beta1 - should apply v2alpha1

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
