### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kyverno PolicyExceptions to v2 and fallback to v2beta1.
+
 ## [0.10.0] - 2024-04-23
 
 - Upgrading to the `v0.9.16` version.

--- a/helm/external-secrets/templates/crd-install/crd-kyverno-policy-exception.yaml
+++ b/helm/external-secrets/templates/crd-install/crd-kyverno-policy-exception.yaml
@@ -1,5 +1,9 @@
-{{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else }}
+apiVersion: kyverno.io/v2beta1
+{{- end }}
 kind: PolicyException
 metadata:
   name: {{ include "external-secrets.name" . }}-crd

--- a/helm/external-secrets/templates/kyverno-policy-exception.yaml
+++ b/helm/external-secrets/templates/kyverno-policy-exception.yaml
@@ -1,5 +1,10 @@
-{{ if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else }}
+apiVersion: kyverno.io/v2beta1
+{{- end }}
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ include "external-secrets.name" . }}


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.