### PR TITLE
Bump appImage to v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump image version to v0.10.5 to resolve issue with failing to auth to
+  kubernetes using client certs
+
 ## [0.11.0] - 2024-10-31
 
 ### Changed

--- a/helm/external-secrets/Chart.yaml
+++ b/helm/external-secrets/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: external-secrets
 description: External secret management for Kubernetes
 type: application
-version: "0.11.0"
-appVersion: "v0.10.4"
+version: "0.11.1"
+appVersion: "v0.10.5"
 upstreamChartVersion: "0.10.5"
 kubeVersion: ">= 1.19.0-0"
 keywords:


### PR DESCRIPTION
When the chart was originally packaged from upstream, upstream had v0.10.4 as its image version (referenced as appVersion in the chart).

This version (v0.10.4) contains a bug
(https://github.com/external-secrets/external-secrets/issues/3998), introduced in v0.9.20 which prevents kubernetes authentication from working correctly, leading to any ExternalSecrets requiring kubernetes auth to fail with the message `failed to prepare auth: no auth provider given`

This change addresses the need by: Bumping the patch version referenced in the chart to v0.10.5 which should contain fix
https://github.com/external-secrets/external-secrets/pull/3952

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
